### PR TITLE
Format web_url to `browse` instead of `rest/api/latest/result`

### DIFF
--- a/lib/cctray/project_build_report_generator.rb
+++ b/lib/cctray/project_build_report_generator.rb
@@ -26,7 +26,7 @@ module CcTray
     end
     
     def format_web_url(web_url)
-      web_url.sub! 'rest/api/latest/result', 'browse'
+      web_url.sub 'rest/api/latest/result', 'browse'
     end
     
     def format_activity(activity)

--- a/lib/cctray/project_build_report_generator.rb
+++ b/lib/cctray/project_build_report_generator.rb
@@ -10,7 +10,7 @@ module CcTray
               :lastBuildLabel => project_build.last_build_label,
               :lastBuildTime => format_last_build_time(project_build.last_build_time),
               :name => project_build.name,
-              :webUrl => project_build.web_url,
+              :webUrl => format_web_url(project_build.web_url),
               :activity => format_activity(project_build.activity),
               :lastBuildStatus => format_last_build_status(project_build.last_build_status)
             )
@@ -23,6 +23,10 @@ module CcTray
     private
     def format_last_build_time(last_build_time)
       last_build_time.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+    end
+    
+    def format_web_url(web_url)
+      web_url.sub! 'rest/api/latest/result', 'browse'
     end
     
     def format_activity(activity)


### PR DESCRIPTION
Thanks for this proxy. Currently on bamboo when I click on a project in CCMenu I get directed to:
`https://bamboo.ship.gov.sg/rest/api/latest/result/<buildprojectcode>` which shows me some XML.
But instead, what I really want to see is the actual build itself, which is at `https://bamboo.ship.gov.sg/browse/<buildprojectcode>`